### PR TITLE
Added C support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ if(MAKE_CLIB OR MAKE_CLIB_STATIC)
 	else()
 		message(STATUS "Building shared library for C Lib")
 	endif()
+else()
+	set(CRYPTONIGHT_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling cryptonite_hash library")
 endif()
 
 # Set a default build configuration if none is specified. 'Release' produces the fastest binaries
@@ -140,6 +142,11 @@ if (WIN32)
   endif()
   
   if(NOT MAKE_CLIB)
+		  # .PYD file extension on Windows
+	  set_target_properties(cryptonite_hash PROPERTIES SUFFIX ".pyd")
+	
+	 # Link against the Python shared library
+	  target_link_libraries(cryptonite_hash ${PYTHON_LIBRARY})
 	  # Strip unnecessary sections of the binary on MINGW
 	  if (MINGW)
 		if(LINK_TYPE EQUAL STATIC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,20 @@ message(STATUS "Target architectures: ${CMAKE_TARGET_ARCHITECTURES}")
 
 project(cryptonite_hash C ASM)
 
+set(LINK_TYPE SHARED)
 # Add a CMake parameter for choosing a desired Python version
+option(MAKE_CLIB "Builds a shared library for C")
+option(MAKE_CLIB_STATIC "Builds a static library for C")
+if(MAKE_CLIB OR MAKE_CLIB_STATIC)
+	add_definitions(-DCLIB)
+	if(MAKE_CLIB_STATIC)
+		set(MAKE_CLIB ON)
+		set(LINK_TYPE STATIC)
+		message(STATUS "Building static library for C Lib")
+	else()
+		message(STATUS "Building shared library for C Lib")
+	endif()
+endif()
 
 # Set a default build configuration if none is specified. 'Release' produces the fastest binaries
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -16,6 +29,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
+# Try to autodetect Python (can be overridden manually if needed)
+set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
+find_package(PythonLibs ${CRYPTONIGHT_PYTHON_VERSION} REQUIRED)
+
+# Include path for Python header files
+include_directories(${PYTHON_INCLUDE_DIR})
+
+# include all subdirs at source directory
 include_directories(${PROJECT_SOURCE_DIR}/.)
 include_directories(${PROJECT_SOURCE_DIR}/crypto)
 
@@ -66,8 +87,10 @@ else()
 endif()
 
 
-# Create the binding library
-add_library(libcryptonite_hash STATIC
+
+if(MAKE_CLIB)
+	# Create the binding library for C
+	add_library(cryptonite_hash ${LINK_TYPE}
    #${PYBIND11_HEADERS}
    ${CRYPTO_HEADERS}
    ${COMPAT_HEADERS}
@@ -81,31 +104,52 @@ add_library(libcryptonite_hash STATIC
    sysinfos.c
   # ... extra files go here ...
 )
-
-add_executable(LibTestOut Libtest.c)
-target_link_libraries(LibTestOut libcryptonite_hash)
-
+set_target_properties(cryptonite_hash PROPERTIES PREFIX "lib")
+else()
+# Create the binding library for python
+add_library(cryptonite_hash SHARED
+   #${PYBIND11_HEADERS}
+   ${CRYPTO_HEADERS}
+   ${COMPAT_HEADERS}
+   ${CRYPTO_SOURCES}
+   ${ASM}
+   compat.h
+   miner.h
+   cryptonite_hash.h
+   cryptonite_hash.c
+   cryptolite_hash.c
+   sysinfos.c
+   cryptonitehashmodule.c
+  # ... extra files go here ...
+)
 # Don't add a 'lib' prefix to the shared library
-set_target_properties(libcryptonite_hash PROPERTIES PREFIX "")
+set_target_properties(cryptonite_hash PROPERTIES PREFIX "")
+endif()
+
 
 if (WIN32)
   if (MSVC)
     # Enforce fastcode generation /O2 /Ot
 	# /bigobj is needed for bigger binding projects due to the limit to 64k addressable sections
     # /MP enables multithreaded builds (relevant when there are many files).
-    set_target_properties(libcryptonite_hash PROPERTIES COMPILE_FLAGS "/O2 /Ot /GL /MP /bigobj /D _CRT_SECURE_NO_WARNINGS")
-    set_target_properties(libcryptonite_hash PROPERTIES LINK_FLAGS "/LTCG")
+    set_target_properties(cryptonite_hash PROPERTIES COMPILE_FLAGS "/O2 /Ot /GL /MP /bigobj /D _CRT_SECURE_NO_WARNINGS")
+    set_target_properties(cryptonite_hash PROPERTIES LINK_FLAGS "/LTCG")
   elseif(MINGW)
-    set_target_properties(libcryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -D_REENTRANT -fmerge-all-constants")
+    set_target_properties(cryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -D_REENTRANT -fmerge-all-constants")
   endif()
   
-  # Strip unnecessary sections of the binary on MINGW
-  if (MINGW)
-    if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      #message(STATUS "Add strip post-build command")
-      #add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -p --strip-debug --strip-unneeded ${PROJECT_BINARY_DIR}/cryptonite_hash.pyd)
-    endif()
-  endif()
+  if(NOT MAKE_CLIB)
+	  # Strip unnecessary sections of the binary on MINGW
+	  if (MINGW)
+		if(LINK_TYPE EQUAL STATIC)
+			set_target_properties(cryptonite_hash PROPERTIES SUFFIX ".a")
+		endif()
+		if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
+		  message(STATUS "Add strip post-build command")
+		  add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -p --strip-debug --strip-unneeded ${PROJECT_BINARY_DIR}/cryptonite_hash.pyd)
+		endif()
+	  endif()
+	endif()
 elseif (UNIX)
   # It's quite common to have multiple copies of the same Python version
   # installed on one's system. E.g.: one copy from the OS and another copy
@@ -120,21 +164,32 @@ elseif (UNIX)
   # missing symbols, but that's perfectly fine -- they will be resolved at
   # import time.
 
-  set_target_properties(libcryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -Wno-pointer-sign -Wno-pointer-to-int-cast")
-  # .SO file extension on Linux/Mac OS
-  set_target_properties(libcryptonite_hash PROPERTIES SUFFIX ".a")
-
-  # Strip unnecessary sections of the binary on Linux/Mac OS
-  message(STATUS "Add strip post-build command")
-  if(APPLE)
-    set_target_properties(cryptonite_hash PROPERTIES MACOSX_RPATH ".")
-    set_target_properties(cryptonite_hash PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -dead_strip")
-    if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      #add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -u -r ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
-    endif()
+  set_target_properties(cryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -Wno-pointer-sign -Wno-pointer-to-int-cast")
+	
+  if(${LINK_TYPE} MATCHES SHARED)
+  	set_target_properties(cryptonite_hash PROPERTIES SUFFIX ".so")
   else()
-    if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      #add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
-    endif()
+	set_target_properties(cryptonite_hash PROPERTIES SUFFIX ".a")
   endif()
+  if(NOT MAKE_CLIB)
+  	# Strip unnecessary sections of the binary on Linux/Mac OS
+	  message(STATUS "Add strip post-build command")
+	  if(APPLE)
+		set_target_properties(cryptonite_hash PROPERTIES MACOSX_RPATH ".")
+		set_target_properties(cryptonite_hash PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -dead_strip")
+		if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
+		  add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -u -r ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
+		endif()
+	  else()
+		if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
+		  add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
+		endif()
+	  endif()
+	endif()
+endif()
+
+
+if(MAKE_CLIB)
+	add_executable(LibTestOut Libtest.c)
+	target_link_libraries(LibTestOut cryptonite_hash)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ message(STATUS "Target architectures: ${CMAKE_TARGET_ARCHITECTURES}")
 project(cryptonite_hash C ASM)
 
 # Add a CMake parameter for choosing a desired Python version
-set(CRYPTONIGHT_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling cryptonite_hash library")
 
 # Set a default build configuration if none is specified. 'Release' produces the fastest binaries
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -17,13 +16,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-# Try to autodetect Python (can be overridden manually if needed)
-set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
-find_package(PythonLibs ${CRYPTONIGHT_PYTHON_VERSION} REQUIRED)
-
-# Include path for Python header files
-include_directories(${PYTHON_INCLUDE_DIR})
-# include all subdirs at source directory
 include_directories(${PROJECT_SOURCE_DIR}/.)
 include_directories(${PROJECT_SOURCE_DIR}/crypto)
 
@@ -75,7 +67,7 @@ endif()
 
 
 # Create the binding library
-add_library(cryptonite_hash SHARED
+add_library(libcryptonite_hash STATIC
    #${PYBIND11_HEADERS}
    ${CRYPTO_HEADERS}
    ${COMPAT_HEADERS}
@@ -87,35 +79,31 @@ add_library(cryptonite_hash SHARED
    cryptonite_hash.c
    cryptolite_hash.c
    sysinfos.c
-   cryptonitehashmodule.c
   # ... extra files go here ...
 )
 
+add_executable(LibTestOut Libtest.c)
+target_link_libraries(LibTestOut libcryptonite_hash)
+
 # Don't add a 'lib' prefix to the shared library
-set_target_properties(cryptonite_hash PROPERTIES PREFIX "")
+set_target_properties(libcryptonite_hash PROPERTIES PREFIX "")
 
 if (WIN32)
   if (MSVC)
     # Enforce fastcode generation /O2 /Ot
 	# /bigobj is needed for bigger binding projects due to the limit to 64k addressable sections
     # /MP enables multithreaded builds (relevant when there are many files).
-    set_target_properties(cryptonite_hash PROPERTIES COMPILE_FLAGS "/O2 /Ot /GL /MP /bigobj /D _CRT_SECURE_NO_WARNINGS")
-    set_target_properties(cryptonite_hash PROPERTIES LINK_FLAGS "/LTCG")
+    set_target_properties(libcryptonite_hash PROPERTIES COMPILE_FLAGS "/O2 /Ot /GL /MP /bigobj /D _CRT_SECURE_NO_WARNINGS")
+    set_target_properties(libcryptonite_hash PROPERTIES LINK_FLAGS "/LTCG")
   elseif(MINGW)
-    set_target_properties(cryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -D_REENTRANT -fmerge-all-constants")
+    set_target_properties(libcryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -D_REENTRANT -fmerge-all-constants")
   endif()
-
-  # .PYD file extension on Windows
-  set_target_properties(cryptonite_hash PROPERTIES SUFFIX ".pyd")
-
-  # Link against the Python shared library
-  target_link_libraries(cryptonite_hash ${PYTHON_LIBRARY})
   
   # Strip unnecessary sections of the binary on MINGW
   if (MINGW)
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      message(STATUS "Add strip post-build command")
-      add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -p --strip-debug --strip-unneeded ${PROJECT_BINARY_DIR}/cryptonite_hash.pyd)
+      #message(STATUS "Add strip post-build command")
+      #add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -p --strip-debug --strip-unneeded ${PROJECT_BINARY_DIR}/cryptonite_hash.pyd)
     endif()
   endif()
 elseif (UNIX)
@@ -132,9 +120,9 @@ elseif (UNIX)
   # missing symbols, but that's perfectly fine -- they will be resolved at
   # import time.
 
-  set_target_properties(cryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -Wno-pointer-sign -Wno-pointer-to-int-cast")
+  set_target_properties(libcryptonite_hash PROPERTIES COMPILE_FLAGS "-O2 -Wno-pointer-sign -Wno-pointer-to-int-cast")
   # .SO file extension on Linux/Mac OS
-  set_target_properties(cryptonite_hash PROPERTIES SUFFIX ".so")
+  set_target_properties(libcryptonite_hash PROPERTIES SUFFIX ".a")
 
   # Strip unnecessary sections of the binary on Linux/Mac OS
   message(STATUS "Add strip post-build command")
@@ -142,11 +130,11 @@ elseif (UNIX)
     set_target_properties(cryptonite_hash PROPERTIES MACOSX_RPATH ".")
     set_target_properties(cryptonite_hash PROPERTIES LINK_FLAGS "-undefined dynamic_lookup -dead_strip")
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -u -r ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
+      #add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip -u -r ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
     endif()
   else()
     if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
-      add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
+      #add_custom_command(TARGET cryptonite_hash POST_BUILD COMMAND strip ${PROJECT_BINARY_DIR}/cryptonite_hash.so)
     endif()
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ if(MAKE_CLIB)
   # ... extra files go here ...
 )
 set_target_properties(cryptonite_hash PROPERTIES PREFIX "lib")
+configure_file(cryptonite_hash_Capi.h cryptonite_hash_Capi.h COPYONLY)
 else()
 # Create the binding library for python
 add_library(cryptonite_hash SHARED

--- a/Libtest.c
+++ b/Libtest.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include "cryptonite_hash.h"
+// gcc -oLibTest Libtest.c 
+
+int main(){
+	char test[] = "This is a test";
+	unsigned char out[32];
+	cryptonight_hash(out, test, sizeof(test)-1, 0);
+	printf("String is: %s\n", test);
+	puts("Hash is: ");
+	for(int i=0; i<32;i++){
+		printf("%02x", out[i]);
+	}
+	puts("\n");
+	unsigned char correct[] = {0xa0,0x84,0xf0,0x1d,0x14,0x37,0xa0,0x9c,0x69,0x85,0x40,0x1b,0x60,0xd4,0x35,0x54,0xae,0x10,0x58,0x02,0xc5,0xf5,0xd8,0xa9,0xb3,0x25,0x36,0x49,0xc0,0xbe,0x66,0x05};
+	for(int i=0; i<32; i++){
+		if(out[i] != correct[i]){
+			puts("Fail");
+			return -1;
+		}
+	}
+	puts("Test passed");
+	return 0;
+}

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 Copyright (c) 2017, Sumokoin.org
 
-This a python-wrapper lib to give cryptonight hashing functions for Sumo Easy Miner
+This a python-wrapper lib with cryptonight hashing functions
 
 To complile on Linux:
 
 	cd /path/to/cryptonight-hash-lib
 	cmake .
+	make
+	
+The library now has C functions. To compile with C:
+	cd /path/to/cryptonight-hash-lib
+	cmake . <-DMAKE_CLIB_STATIC=ON/-DMAKE_CLIB=ON>
 	make

--- a/cryptonite_hash.c
+++ b/cryptonite_hash.c
@@ -311,7 +311,20 @@ void cryptonight_hash_ctx_aes_ni(void* output, const void* input, int len, struc
 
 
 //bool aes_ni_supported = false;
-
+#ifndef CLIB
+void cryptonight_hash(void* output, const void* input,const int aes_ni_supported) {
+	struct cryptonight_ctx *ctx = (struct cryptonight_ctx*)malloc(sizeof(struct cryptonight_ctx));
+	
+	if (aes_ni_supported) {
+		cryptonight_hash_ctx_aes_ni(output, input, 76, ctx);
+	}
+	else
+	{
+		cryptonight_hash_ctx(output, input, 76, ctx);
+	}
+	free(ctx);
+}
+#else
 void cryptonight_hash(void* output, const void* input, unsigned int length,const int aes_ni_supported) {
 	struct cryptonight_ctx *ctx = (struct cryptonight_ctx*)malloc(sizeof(struct cryptonight_ctx));
 	
@@ -324,7 +337,7 @@ void cryptonight_hash(void* output, const void* input, unsigned int length,const
 	}
 	free(ctx);
 }
-
+#endif
 
 int scanhash_cryptonight(char* pdata, uint32_t target,
 										uint32_t max_nonce, uint64_t* hashes_done)

--- a/cryptonite_hash.c
+++ b/cryptonite_hash.c
@@ -312,15 +312,15 @@ void cryptonight_hash_ctx_aes_ni(void* output, const void* input, int len, struc
 
 //bool aes_ni_supported = false;
 
-void cryptonight_hash(void* output, const void* input, const int aes_ni_supported) {
+void cryptonight_hash(void* output, const void* input, unsigned int length,const int aes_ni_supported) {
 	struct cryptonight_ctx *ctx = (struct cryptonight_ctx*)malloc(sizeof(struct cryptonight_ctx));
 	
 	if (aes_ni_supported) {
-		cryptonight_hash_ctx_aes_ni(output, input, 76, ctx);
+		cryptonight_hash_ctx_aes_ni(output, input, length, ctx);
 	}
 	else
 	{
-		cryptonight_hash_ctx(output, input, 76, ctx);
+		cryptonight_hash_ctx(output, input, length, ctx);
 	}
 	free(ctx);
 }

--- a/cryptonite_hash.h
+++ b/cryptonite_hash.h
@@ -4,11 +4,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void cryptonight_hash(void* output, const void* input, const int aes_ni_supported);
-int scanhash_cryptonight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
+void cryptonight_hash(void* output, const void* input, unsigned int length,const int aes_ni_supported);
+//int scanhash_cryptonight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
 
-void cryptolight_hash(void* output, const void* input, const int aes_ni_supported);
-int scanhash_cryptolight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
+//void cryptolight_hash(void* output, const void* input, const int aes_ni_supported);
+//int scanhash_cryptolight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
 
 bool has_aes_ni(void);
 void bestcpu_feature(char *outbuf, int maxsz);

--- a/cryptonite_hash.h
+++ b/cryptonite_hash.h
@@ -4,14 +4,22 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void cryptonight_hash(void* output, const void* input, unsigned int length,const int aes_ni_supported);
-//int scanhash_cryptonight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
+#ifndef CLIB
+void cryptonight_hash(void* output, const void* input,const int aes_ni_supported);
+int scanhash_cryptonight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
 
-//void cryptolight_hash(void* output, const void* input, const int aes_ni_supported);
-//int scanhash_cryptolight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
+void cryptolight_hash(void* output, const void* input, const int aes_ni_supported);
+int scanhash_cryptolight(char* pdata, uint32_t target, uint32_t max_nonce, uint64_t* hashes_done);
 
 bool has_aes_ni(void);
 void bestcpu_feature(char *outbuf, int maxsz);
 float cpu_temp(int core);
+#else
+
+void cryptonight_hash(void* output, const void* input,unsigned int length,const int aes_ni_supported);
+bool has_aes_ni(void);
+void bestcpu_feature(char *outbuf, int maxsz);
+float cpu_temp(int core);
+#endif
 
 #endif /* CRYPTONIGHT_H */

--- a/cryptonite_hash_Capi.h
+++ b/cryptonite_hash_Capi.h
@@ -1,0 +1,12 @@
+#ifndef CRYPTONITE_HASH_CAPI_H
+#define CRYPTONITE_HASH_CAPI_H
+
+void cryptonight_hash(void* output, const void* input,unsigned int length,const int aes_ni_supported);
+bool has_aes_ni(void);
+void bestcpu_feature(char *outbuf, int maxsz);
+float cpu_temp(int core);
+
+
+
+
+#endif


### PR DESCRIPTION
The original author/authors did an amazing job creating this library for python. It is easily the best one I've seen. I was working on a C program that needed the cryptonight hash function, and stumbled across this library. The only problem was that I couldn't use it because of the python hooks. I changed up the cmake file so that there is now 2 more options:
MAKE_CLIB_STATIC
MAKE_CLIB
I tried to preserve the original make file so that it does not interfere with the python lib that can be generated. The header  cryptonite_hash has the  macro flag CLIB that choose between the function needed for the C library and the function originally defined by the author. I hope this small change will be added to the project because it would be of great use to other C and C++ programmers.

Happy to take any criticism, always trying to improve